### PR TITLE
fixed gemfile syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "http://rubygems.org"
 
-nokogiri
+gem 'nokogiri'


### PR DESCRIPTION
previous syntax would throw: `[!] There was an error parsing 'Gemfile': Undefined local variable or method`nokogiri' for Gemfile.` in ruby 2.3.0.
